### PR TITLE
ci: rollout go 1.18 in favor of go 1.21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,12 @@ on:
       - main
 env:
   DD_APPSEC_WAF_TIMEOUT: 5s
-  GODEBUG: cgocheck=2 # highest level of run-time cgo checks
 jobs:
   native:
     strategy:
       matrix:
         runs-on: [ macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, windows-latest ]
-        go-version: [ "1.20", "1.19", "1.18" ]
+        go-version: [ "1.21", "1.20", "1.19" ]
         cgo_enabled: # test it compiles with and without cgo
           - 0
           - 1
@@ -50,7 +49,7 @@ jobs:
       image: golang:${{ matrix.go-version }}-${{ matrix.distribution }}
     strategy:
       matrix:
-        go-version: [ "1.20", "1.19", "1.18" ]
+        go-version: [ "1.21", "1.20", "1.19" ]
         distribution: [ bullseye, buster, alpine ]
         cgo_enabled: # test it compiles with and without cgo
           - 0


### PR DESCRIPTION
removed CGOCHECK as it is unavailable in go 1.21