### PR TITLE
appsec: add rate limiter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.2
+	go.uber.org/atomic v1.11.0
 	inet.af/netaddr v0.0.0-20220811202034-502d2d690317
 )
 

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go4.org/intern v0.0.0-20211027215823-ae77deb06f29 h1:UXLjNohABv4S58tHmeuIZDO6e3mHpW2Dx33gaNt03LE=
 go4.org/intern v0.0.0-20211027215823-ae77deb06f29/go.mod h1:cS2ma+47FKrLPdXFpr7CuxiTW3eyJbWew4qx0qtQWDA=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=

--- a/limiter/limiter.go
+++ b/limiter/limiter.go
@@ -1,0 +1,141 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package limiter
+
+import (
+	"time"
+
+	"go.uber.org/atomic"
+)
+
+// Limiter is used to abstract the rate limiter implementation to only expose the needed function for rate limiting.
+// This is for example useful for testing, allowing us to use a modified rate limiter tuned for testing through the same
+// interface.
+type Limiter interface {
+	Allow() bool
+}
+
+// TokenTicker is a thread-safe and lock-free rate limiter based on a token bucket.
+// The idea is to have a goroutine that will update  the bucket with fresh tokens at regular intervals using a time.Ticker.
+// The advantage of using a goroutine here is  that the implementation becomes easily thread-safe using a few
+// atomic operations with little overhead overall. TokenTicker.Start() *should* be called before the first call to
+// TokenTicker.Allow() and TokenTicker.Stop() *must* be called once done using. Note that calling TokenTicker.Allow()
+// before TokenTicker.Start() is valid, but it means the bucket won't be refilling until the call to TokenTicker.Start() is made
+type TokenTicker struct {
+	tokens    atomic.Int64
+	maxTokens int64
+	ticker    *time.Ticker
+	stopChan  chan struct{}
+}
+
+// NewTokenTicker is a utility function that allocates a token ticker, initializes necessary fields and returns it
+func NewTokenTicker(tokens, maxTokens int64) *TokenTicker {
+	return &TokenTicker{
+		tokens:    *atomic.NewInt64(tokens),
+		maxTokens: maxTokens,
+	}
+}
+
+// updateBucket performs a select loop to update the token amount in the bucket.
+// Used in a goroutine by the rate limiter.
+func (t *TokenTicker) updateBucket(ticksChan <-chan time.Time, startTime time.Time, syncChan chan struct{}) {
+	nsPerToken := time.Second.Nanoseconds() / t.maxTokens
+	elapsedNs := int64(0)
+	prevStamp := startTime
+
+	for {
+		select {
+		case <-t.stopChan:
+			if syncChan != nil {
+				close(syncChan)
+			}
+			return
+		case stamp := <-ticksChan:
+			// Compute the time in nanoseconds that passed between the previous timestamp and this one
+			// This will be used to know how many tokens can be added into the bucket depending on the limiter rate
+			elapsedNs += stamp.Sub(prevStamp).Nanoseconds()
+			if elapsedNs > t.maxTokens*nsPerToken {
+				elapsedNs = t.maxTokens * nsPerToken
+			}
+			prevStamp = stamp
+			// Update the number of tokens in the bucket if enough nanoseconds have passed
+			if elapsedNs >= nsPerToken {
+				// Atomic spin lock to make sure we don't race for `t.tokens`
+				for {
+					tokens := t.tokens.Load()
+					if tokens == t.maxTokens {
+						break // Bucket is already full, nothing to do
+					}
+					inc := elapsedNs / nsPerToken
+					// Make sure not to add more tokens than we are allowed to into the bucket
+					if tokens+inc > t.maxTokens {
+						inc -= (tokens + inc) % t.maxTokens
+					}
+					if t.tokens.CompareAndSwap(tokens, tokens+inc) {
+						// Keep track of remaining elapsed ns that were not taken into account for this computation,
+						// so that increment computation remains precise over time
+						elapsedNs = elapsedNs % nsPerToken
+						break
+					}
+				}
+			}
+			// Sync channel used to signify that the goroutine is done updating the bucket. Used for tests to guarantee
+			// that the goroutine ticked at least once.
+			if syncChan != nil {
+				syncChan <- struct{}{}
+			}
+		}
+	}
+}
+
+// Start starts the ticker and launches the goroutine responsible for updating the token bucket.
+// The ticker is set to tick at a fixed rate of 500us.
+func (t *TokenTicker) Start() {
+	timeNow := time.Now()
+	t.ticker = time.NewTicker(500 * time.Microsecond)
+	t.start(t.ticker.C, timeNow, false)
+}
+
+// start is used for internal testing. Controlling the ticker means being able to test per-tick
+// rather than per-duration, which is more reliable if the app is under a lot of stress.
+// sync is used to decide whether the limiter should create a channel for synchronization with the testing app after a
+// bucket update. The limiter is in charge of closing the channel in this case.
+func (t *TokenTicker) start(ticksChan <-chan time.Time, startTime time.Time, sync bool) <-chan struct{} {
+	t.stopChan = make(chan struct{})
+	var syncChan chan struct{}
+
+	if sync {
+		syncChan = make(chan struct{})
+	}
+	go t.updateBucket(ticksChan, startTime, syncChan)
+	return syncChan
+}
+
+// Stop shuts down the rate limiter, taking care stopping the ticker and closing all channels
+func (t *TokenTicker) Stop() {
+	// Stop the ticker only if it has been instantiated (not the case when testing by calling start() directly)
+	if t.ticker != nil {
+		t.ticker.Stop()
+	}
+	// Close the stop channel only if it has been created. This covers the case where Stop() is called without any prior
+	// call to Start()
+	if t.stopChan != nil {
+		close(t.stopChan)
+	}
+}
+
+// Allow checks and returns whether a token can be retrieved from the bucket and consumed.
+// Thread-safe.
+func (t *TokenTicker) Allow() bool {
+	for {
+		tokens := t.tokens.Load()
+		if tokens == 0 {
+			return false
+		} else if t.tokens.CompareAndSwap(tokens, tokens-1) {
+			return true
+		}
+	}
+}

--- a/limiter/limiter_test.go
+++ b/limiter/limiter_test.go
@@ -1,0 +1,302 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package limiter
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+func TestLimiterUnit(t *testing.T) {
+	startTime := time.Now()
+
+	t.Run("no-ticks-1", func(t *testing.T) {
+		l := NewTestTicker(1, 100)
+		l.start(startTime)
+		defer l.stop()
+		// No ticks between the requests
+		require.True(t, l.Allow(), "First call to limiter.Allow() should return True")
+		require.False(t, l.Allow(), "Second call to limiter.Allow() should return False")
+	})
+
+	t.Run("no-ticks-2", func(t *testing.T) {
+		l := NewTestTicker(100, 100)
+		l.start(startTime)
+		defer l.stop()
+		// No ticks between the requests
+		for i := 0; i < 100; i++ {
+			require.True(t, l.Allow())
+		}
+		require.False(t, l.Allow())
+	})
+
+	t.Run("10ms-ticks", func(t *testing.T) {
+		l := NewTestTicker(1, 100)
+		l.start(startTime)
+		defer l.stop()
+		require.True(t, l.Allow(), "First call to limiter.Allow() should return True")
+		require.False(t, l.Allow(), "Second call to limiter.Allow() should return false")
+		l.tick(startTime.Add(10 * time.Millisecond))
+		require.True(t, l.Allow(), "Third call to limiter.Allow() after 10ms should return True")
+	})
+
+	t.Run("9ms-ticks", func(t *testing.T) {
+		l := NewTestTicker(1, 100)
+		l.start(startTime)
+		defer l.stop()
+		require.True(t, l.Allow(), "First call to limiter.Allow() should return True")
+		l.tick(startTime.Add(9 * time.Millisecond))
+		require.False(t, l.Allow(), "Second call to limiter.Allow() after 9ms should return False")
+		l.tick(startTime.Add(10 * time.Millisecond))
+		require.True(t, l.Allow(), "Third call to limiter.Allow() after 10ms should return True")
+	})
+
+	t.Run("1s-rate", func(t *testing.T) {
+		l := NewTestTicker(1, 1)
+		l.start(startTime)
+		defer l.stop()
+		require.True(t, l.Allow(), "First call to limiter.Allow() should return True with 1s per token")
+		l.tick(startTime.Add(500 * time.Millisecond))
+		require.False(t, l.Allow(), "Second call to limiter.Allow() should return False with 1s per Token")
+		l.tick(startTime.Add(1000 * time.Millisecond))
+		require.True(t, l.Allow(), "Third call to limiter.Allow() should return True with 1s per Token")
+	})
+
+	t.Run("100-requests-burst", func(t *testing.T) {
+		l := NewTestTicker(100, 100)
+		l.start(startTime)
+		defer l.stop()
+		for i := 0; i < 100; i++ {
+			require.Truef(t, l.Allow(),
+				"Burst call %d to limiter.Allow() should return True with 100 initial tokens", i)
+			startTime = startTime.Add(50 * time.Microsecond)
+			l.tick(startTime)
+		}
+	})
+
+	t.Run("101-requests-burst", func(t *testing.T) {
+		l := NewTestTicker(100, 100)
+		l.start(startTime)
+		defer l.stop()
+		for i := 0; i < 100; i++ {
+			require.Truef(t, l.Allow(),
+				"Burst call %d to limiter.Allow() should return True with 100 initial tokens", i)
+			startTime = startTime.Add(50 * time.Microsecond)
+			l.tick(startTime)
+		}
+		require.False(t, l.Allow(),
+			"Burst call 101 to limiter.Allow() should return False with 100 initial tokens")
+	})
+
+	t.Run("bucket-refill-short", func(t *testing.T) {
+		l := NewTestTicker(100, 100)
+		l.start(startTime)
+		defer l.stop()
+
+		for i := 0; i < 1000; i++ {
+			startTime = startTime.Add(time.Millisecond)
+			l.tick(startTime)
+			require.Equalf(t, int64(100), l.t.tokens.Load(), "Bucket should have exactly 100 tokens")
+		}
+	})
+
+	t.Run("bucket-refill-long", func(t *testing.T) {
+		l := NewTestTicker(100, 100)
+		l.start(startTime)
+		defer l.stop()
+
+		for i := 0; i < 1000; i++ {
+			startTime = startTime.Add(3 * time.Second)
+			l.tick(startTime)
+		}
+		require.Equalf(t, int64(100), l.t.tokens.Load(), "Bucket should have exactly 100 tokens")
+	})
+
+	t.Run("allow-after-stop", func(t *testing.T) {
+		l := NewTestTicker(3, 3)
+		l.start(startTime)
+		require.True(t, l.Allow())
+		l.stop()
+		// The limiter keeps allowing until there's no more tokens
+		require.True(t, l.Allow())
+		require.True(t, l.Allow())
+		require.False(t, l.Allow())
+	})
+
+	t.Run("allow-before-start", func(t *testing.T) {
+		l := NewTestTicker(2, 100)
+		// The limiter keeps allowing until there's no more tokens
+		require.True(t, l.Allow())
+		require.True(t, l.Allow())
+		require.False(t, l.Allow())
+		l.start(startTime)
+		// The limiter has used all its tokens and the bucket is not getting refilled yet
+		require.False(t, l.Allow())
+		l.tick(startTime.Add(10 * time.Millisecond))
+		// The limiter has started refilling its tokens
+		require.True(t, l.Allow())
+		l.stop()
+	})
+}
+
+func TestLimiter(t *testing.T) {
+	t.Run("concurrency", func(t *testing.T) {
+		// Tests the limiter's ability to sample the traces when subjected to a continuous flow of requests
+		// Each goroutine will continuously call the rate limiter for 1 second
+		for nbUsers := 1; nbUsers <= 10; nbUsers *= 10 {
+			t.Run(fmt.Sprintf("continuous-requests-%d-users", nbUsers), func(t *testing.T) {
+				var startBarrier, stopBarrier sync.WaitGroup
+				// Create a start barrier to synchronize every goroutine's launch and
+				// increase the chances of parallel accesses
+				startBarrier.Add(1)
+				// Create a stopBarrier to signal when all user goroutines are done.
+				stopBarrier.Add(nbUsers)
+				var skipped, kept atomic.Uint64
+				l := NewTokenTicker(0, 100)
+
+				for n := 0; n < nbUsers; n++ {
+					go func(l Limiter, kept, skipped *atomic.Uint64) {
+						startBarrier.Wait()      // Sync the starts of the goroutines
+						defer stopBarrier.Done() // Signal we are done when returning
+
+						for tStart := time.Now(); time.Since(tStart) < 1*time.Second; {
+							if !l.Allow() {
+								skipped.Inc()
+							} else {
+								kept.Inc()
+							}
+						}
+					}(l, &kept, &skipped)
+				}
+
+				l.Start()
+				defer l.Stop()
+				start := time.Now()
+				startBarrier.Done() // Unblock the user goroutines
+				stopBarrier.Wait()  // Wait for the user goroutines to be done
+				duration := time.Since(start).Seconds()
+				maxExpectedKept := uint64(math.Ceil(duration) * 100)
+
+				require.LessOrEqualf(t, kept.Load(), maxExpectedKept,
+					"Expected at most %d kept tokens for a %fs duration", maxExpectedKept, duration)
+			})
+		}
+
+		burstFreq := 1000 * time.Millisecond
+		burstSize := 101
+		startTime := time.Now()
+		// Simulate sporadic bursts during up to 1 minute
+		for burstAmount := 1; burstAmount <= 10; burstAmount++ {
+			t.Run(fmt.Sprintf("requests-bursts-%d-iterations", burstAmount), func(t *testing.T) {
+				skipped := 0
+				kept := 0
+				l := NewTestTicker(100, 100)
+				l.start(startTime)
+				defer l.stop()
+
+				for c := 0; c < burstAmount; c++ {
+					for i := 0; i < burstSize; i++ {
+						if !l.Allow() {
+							skipped++
+						} else {
+							kept++
+						}
+					}
+					// Schedule next burst 1sec later
+					startTime = startTime.Add(burstFreq)
+					l.tick(startTime)
+				}
+
+				expectedSkipped := (burstSize - 100) * burstAmount
+				expectedKept := 100 * burstAmount
+				if burstSize < 100 {
+					expectedSkipped = 0
+					expectedKept = burstSize * burstAmount
+				}
+				require.Equalf(t, kept, expectedKept, "Expected %d burst requests to be kept", expectedKept)
+				require.Equalf(t, expectedSkipped, skipped, "Expected %d burst requests to be skipped", expectedSkipped)
+			})
+		}
+	})
+}
+
+func BenchmarkLimiter(b *testing.B) {
+	for nbUsers := 1; nbUsers <= 1000; nbUsers *= 10 {
+		b.Run(fmt.Sprintf("%d-users", nbUsers), func(b *testing.B) {
+			var skipped, kept atomic.Uint64
+			limiter := NewTokenTicker(0, 100)
+			limiter.Start()
+			defer limiter.Stop()
+			b.ResetTimer()
+
+			for n := 0; n < b.N; n++ {
+				var startBarrier, stopBarrier sync.WaitGroup
+				// Create a start barrier to synchronize every goroutine's launch and
+				// increase the chances of parallel accesses
+				startBarrier.Add(1)
+				// Create a stopBarrier to signal when all user goroutines are done.
+				stopBarrier.Add(nbUsers)
+
+				for n := 0; n < nbUsers; n++ {
+					go func(l Limiter, kept, skipped *atomic.Uint64) {
+						startBarrier.Wait()      // Sync the starts of the goroutines
+						defer stopBarrier.Done() // Signal we are done when returning
+
+						for i := 0; i < 100; i++ {
+							if !l.Allow() {
+								skipped.Inc()
+							} else {
+								kept.Inc()
+							}
+						}
+					}(limiter, &kept, &skipped)
+				}
+				startBarrier.Done() // Unblock the user goroutines
+				stopBarrier.Wait()  // Wait for the user goroutines to be done
+			}
+		})
+	}
+}
+
+// TestTicker is a utility struct used to send hand-crafted ticks to the rate limiter for controlled testing
+// It also makes sure to give time to the bucket update goroutine by using the optional sync channel
+type TestTicker struct {
+	C        chan time.Time
+	syncChan <-chan struct{}
+	t        *TokenTicker
+}
+
+func NewTestTicker(tokens, maxTokens int64) *TestTicker {
+	return &TestTicker{
+		C: make(chan time.Time),
+		t: NewTokenTicker(tokens, maxTokens),
+	}
+}
+
+func (t *TestTicker) start(timeStamp time.Time) {
+	t.syncChan = t.t.start(t.C, timeStamp, true)
+}
+
+func (t *TestTicker) stop() {
+	t.t.Stop()
+	close(t.C)
+	// syncChan is closed by the token ticker when sure that nothing else will be sent on it
+}
+
+func (t *TestTicker) tick(timeStamp time.Time) {
+	t.C <- timeStamp
+	<-t.syncChan
+}
+
+func (t *TestTicker) Allow() bool {
+	return t.t.Allow()
+}


### PR DESCRIPTION
Previously duplicated code between datadog-agent/pkg/serverless/appsec and dd-trace-go/internal/appsec