### PR TITLE
static rules: add processors json config

### DIFF
--- a/_tools/rules-updater/Dockerfile
+++ b/_tools/rules-updater/Dockerfile
@@ -4,8 +4,8 @@ ENV VERSION=$version
 ADD https://raw.githubusercontent.com/DataDog/appsec-event-rules/$version/build/recommended.json /home/rules.json
 COPY writer/ /home/
 WORKDIR /home/
-RUN go run writer.go ${VERSION} > rules.go
+RUN go run writer.go ${VERSION} > embed.go
 
 FROM scratch
-COPY --from=go-format /home/rules.go rules.go
+COPY --from=go-format /home/embed.go embed.go
 COPY --from=go-format /home/rules.json rules.json

--- a/_tools/rules-updater/update.sh
+++ b/_tools/rules-updater/update.sh
@@ -26,6 +26,6 @@ trap "rm -r $tmpDir" EXIT
 
 DOCKER_BUILDKIT=1 docker build -o type=local,dest="$tmpDir" --build-arg version="$1" --no-cache "$scriptDir"
 echo "================   Done    ================"
-cp -v $tmpDir/rules.go "$destDir"
+cp -v $tmpDir/embed.go "$destDir"
 cp -v $tmpDir/rules.json "$destDir"
 echo "Output written to $destDir"

--- a/_tools/rules-updater/writer/template.txt
+++ b/_tools/rules-updater/writer/template.txt
@@ -12,3 +12,9 @@ import _ "embed" // Blank import comment for golint compliance
 //
 //go:embed rules.json
 var StaticRecommendedRules string
+
+// StaticProcessors holds the default processors and scanners used for API Security
+// Not part of the recommended security rules
+//
+//go:embed processors.json
+var StaticProcessors string

--- a/appsec/embed.go
+++ b/appsec/embed.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package appsec
+
+import _ "embed" // Blank import comment for golint compliance
+
+// StaticRecommendedRules holds the recommended AppSec security rules (v1.8.0)
+// Source: https://github.com/DataDog/appsec-event-rules/blob/1.8.0/build/recommended.json
+//
+//go:embed rules.json
+var StaticRecommendedRules string
+
+// StaticProcessors holds the default processors and scanners used for API Security
+// Not part of the recommended security rules
+//
+//go:embed processors.json
+var StaticProcessors string

--- a/appsec/processors.json
+++ b/appsec/processors.json
@@ -1,0 +1,208 @@
+{
+  "processors": [
+    {
+      "id": "processor-001",
+      "generator": "extract_schema",
+      "conditions": [
+        {
+          "operator": "equals",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "waf.context.processor",
+                "key_path": [
+                  "extract-schema"
+                ]
+              }
+            ],
+            "type": "boolean",
+            "value": true
+          }
+        }
+      ],
+      "parameters": {
+        "mappings": [
+          {
+            "inputs": [
+              {
+                "address": "server.request.body"
+              }
+            ],
+            "output": "_dd.appsec.s.req.body"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "output": "_dd.appsec.s.req.headers"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              }
+            ],
+            "output": "_dd.appsec.s.req.query"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "output": "_dd.appsec.s.req.params"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              }
+            ],
+            "output": "_dd.appsec.s.req.cookies"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.response.headers.no_cookies"
+              }
+            ],
+            "output": "_dd.appsec.s.res.headers"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.response.body"
+              }
+            ],
+            "output": "_dd.appsec.s.res.body"
+          }
+        ],
+        "scanners": [
+          {
+            "tags": {
+              "category": "pii"
+            }
+          }
+        ]
+      },
+      "evaluate": false,
+      "output": true
+    }
+  ],
+  "scanners": [
+    {
+      "id": "d962f7ddb3f55041e39195a60ff79d4814a7c331",
+      "name": "US Passport Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "passport",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 8
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b[0-9A-Z]{9}\\b|\\b[0-9]{6}[A-Z][0-9]{2}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 8
+          }
+        }
+      },
+      "tags": {
+        "type": "passport_number",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "ac6d683cbac77f6e399a14990793dd8fd0fca333",
+      "name": "US Vehicle Identification Number Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "vehicle[_\\s-]*identification[_\\s-]*number|vin",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b[A-HJ-NPR-Z0-9]{17}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 17
+          }
+        }
+      },
+      "tags": {
+        "type": "vin",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "de0899e0cbaaa812bb624cf04c912071012f616d",
+      "name": "UK National Insurance Number Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "national[\\s_]?(?:insurance(?:\\s+number)?)?|NIN|NI[\\s_]?number|insurance[\\s_]?number",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b[A-Z]{2}\\d{6}[A-Z]?\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 8
+          }
+        }
+      },
+      "tags": {
+        "type": "uk_nin",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "450239afc250a19799b6c03dc0e16fd6a4b2a1af",
+      "name": "Canadian Social Insurance Number Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "social[\\s_]?(?:insurance(?:\\s+number)?)?|SIN|Canadian[\\s_]?(?:social[\\s_]?(?:insurance)?|insurance[\\s_]?number)?",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b\\d{3}-\\d{3}-\\d{3}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 11
+          }
+        }
+      },
+      "tags": {
+        "type": "canadian_sin",
+        "category": "pii"
+      }
+    }
+  ]
+}

--- a/appsec/rules.go
+++ b/appsec/rules.go
@@ -1,20 +1,24 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
-
+// Copyright 2023-present Datadog, Inc.
 package appsec
 
-import _ "embed" // Blank import comment for golint compliance
+import "encoding/json"
 
-// StaticRecommendedRules holds the recommended AppSec security rules (v1.9.0)
-// Source: https://github.com/DataDog/appsec-event-rules/blob/1.9.0/build/recommended.json
-//
-//go:embed rules.json
-var StaticRecommendedRules string
+// DefaultRuleset returns the default recommended security rules for AppSec
+func DefaultRuleset() ([]byte, error) {
+	var rules map[string]any
+	var processors map[string]any
+	if err := json.Unmarshal([]byte(StaticRecommendedRules), &rules); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal([]byte(StaticProcessors), &processors); err != nil {
+		return nil, err
+	}
+	for k, v := range processors {
+		rules[k] = v
+	}
 
-// StaticProcessors holds the default processors and scanners used for API Security
-// Not part of the recommended security rules
-//
-//go:embed processors.json
-var StaticProcessors string
+	return json.Marshal(rules)
+}

--- a/appsec/rules.go
+++ b/appsec/rules.go
@@ -12,3 +12,9 @@ import _ "embed" // Blank import comment for golint compliance
 //
 //go:embed rules.json
 var StaticRecommendedRules string
+
+// StaticProcessors holds the default processors and scanners used for API Security
+// Not part of the recommended security rules
+//
+//go:embed processors.json
+var StaticProcessors string


### PR DESCRIPTION
The processors config for schema extraction is currently not part of the defaul ruleset and needs to be added by the libraries. We will need to access it both from datadog-agent and dd-trace-go so it makes sense to export it along the default ruleset.

Moving embed to a dedicated file so that we don't keep API code in a txt template.