### PR TITLE
Shared configurations

### DIFF
--- a/appsec/config.go
+++ b/appsec/config.go
@@ -1,0 +1,90 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package appsec
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// Configuration environment variables
+const (
+	envAPISecEnabled    = "DD_EXPERIMENTAL_API_SECURITY_ENABLED"
+	envAPISecSampleRate = "DD_API_SECURITY_REQUEST_SAMPLE_RATE"
+	envObfuscatorKey    = "DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP"
+	envObfuscatorValue  = "DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP"
+)
+
+// Configuration constants and default values
+const (
+	defaultAPISecSampleRate     = 10. / 100
+	defaultObfuscatorKeyRegex   = `(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?)key)|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization`
+	defaultObfuscatorValueRegex = `(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:\s*=[^;]|"\s*:\s*"[^"]+")|bearer\s+[a-z0-9\._\-]+|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\w=-]+\.ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}[^\-]+[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,}`
+)
+
+// APISecConfig holds the configuration for API Security schemas reporting
+// It is used to enabled/disable the feature as well as to configure the rate
+// at which schemas get reported,
+type APISecConfig struct {
+	Enabled    bool
+	SampleRate float64
+}
+
+// ObfuscatorConfig wraps the key and value regexp to be passed to the WAF to perform obfuscation.
+type ObfuscatorConfig struct {
+	KeyRegex   string
+	ValueRegex string
+}
+
+// NewAPISecConfig creates and returns a new API Security configuration by reading the env
+func NewAPISecConfig() APISecConfig {
+	return APISecConfig{
+		Enabled:    apiSecurityEnabled(),
+		SampleRate: readAPISecuritySampleRate(),
+	}
+}
+
+func apiSecurityEnabled() bool {
+	enabled, _ := strconv.ParseBool(os.Getenv(envAPISecEnabled))
+	return enabled
+}
+
+func readAPISecuritySampleRate() float64 {
+	rate, err := strconv.ParseFloat(os.Getenv(envAPISecSampleRate), 64)
+	if err != nil {
+		log.Debugf("appsec: could not parse %s. Defaulting to %f", envAPISecSampleRate, defaultAPISecSampleRate)
+		return defaultAPISecSampleRate
+	}
+	if rate < 0. || rate > 1. {
+		log.Debugf("appsec: %s value must be between 0 and 1. Defaulting to %f", envAPISecSampleRate, defaultAPISecSampleRate)
+		return defaultAPISecSampleRate
+	}
+	return rate
+}
+
+// NewObfuscatorConfig creates and returns a new WAF obfuscator configuration by reading the env
+func NewObfuscatorConfig() ObfuscatorConfig {
+	keyRE := readObfuscatorConfigRegexp(envObfuscatorKey, defaultObfuscatorKeyRegex)
+	valueRE := readObfuscatorConfigRegexp(envObfuscatorValue, defaultObfuscatorValueRegex)
+	return ObfuscatorConfig{KeyRegex: keyRE, ValueRegex: valueRE}
+}
+
+func readObfuscatorConfigRegexp(name, defaultValue string) string {
+	val, present := os.LookupEnv(name)
+	if !present {
+		log.Debug("appsec: %s not defined, starting with the default obfuscator regular expression", name)
+		return defaultValue
+	}
+	if _, err := regexp.Compile(val); err != nil {
+		log.Errorf("appsec: could not compile the configured obfuscator regular expression `%s=%s`. Using the default value instead", name, val)
+		return defaultValue
+	}
+	log.Debug("appsec: starting with the configured obfuscator regular expression %s", name)
+	return val
+}

--- a/appsec/config.go
+++ b/appsec/config.go
@@ -29,11 +29,11 @@ const (
 
 // Configuration constants and default values
 const (
-	defaultAPISecSampleRate     = 10. / 100
-	defaultObfuscatorKeyRegex   = `(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?)key)|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization`
-	defaultObfuscatorValueRegex = `(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:\s*=[^;]|"\s*:\s*"[^"]+")|bearer\s+[a-z0-9\._\-]+|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\w=-]+\.ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}[^\-]+[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,}`
-	defaultWAFTimeout           = 4 * time.Millisecond
-	defaultTraceRate            = uint(100) // up to 100 appsec traces/s
+	defaultAPISecSampleRate          = .1
+	defaultObfuscatorKeyRegex        = `(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?)key)|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization`
+	defaultObfuscatorValueRegex      = `(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:\s*=[^;]|"\s*:\s*"[^"]+")|bearer\s+[a-z0-9\._\-]+|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\w=-]+\.ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}[^\-]+[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,}`
+	defaultWAFTimeout                = 4 * time.Millisecond
+	defaultTraceRate            uint = 100 // up to 100 appsec traces/s
 )
 
 // APISecConfig holds the configuration for API Security schemas reporting
@@ -165,10 +165,10 @@ func RulesFromEnv() ([]byte, error) {
 	return buf, nil
 }
 
-func logEnvVarParsingError(name, value string, err error, defaultValue interface{}) {
+func logEnvVarParsingError(name, value string, err error, defaultValue any) {
 	log.Errorf("appsec: could not parse the env var %s=%s as a duration: %v. Using default value %v.", name, value, err, defaultValue)
 }
 
-func logUnexpectedEnvVarValue(name string, value interface{}, reason string, defaultValue interface{}) {
+func logUnexpectedEnvVarValue(name string, value any, reason string, defaultValue any) {
 	log.Errorf("appsec: unexpected configuration value of %s=%v: %s. Using default value %v.", name, value, reason, defaultValue)
 }

--- a/appsec/config.go
+++ b/appsec/config.go
@@ -70,9 +70,11 @@ func readAPISecuritySampleRate() float64 {
 		logEnvVarParsingError(envAPISecSampleRate, value, err, defaultAPISecSampleRate)
 		return defaultAPISecSampleRate
 	}
-	if rate < 0. || rate > 1. {
-		logUnexpectedEnvVarValue(envAPISecSampleRate, rate, "value must be between 0 and 1", defaultAPISecSampleRate)
-		return defaultAPISecSampleRate
+	// Clamp the value so that 0.0 <= rate <= 1.0
+	if rate < 0. {
+		rate = 0.
+	} else if rate > 1. {
+		rate = 1.
 	}
 	return rate
 }

--- a/appsec/config.go
+++ b/appsec/config.go
@@ -63,13 +63,14 @@ func apiSecurityEnabled() bool {
 }
 
 func readAPISecuritySampleRate() float64 {
-	rate, err := strconv.ParseFloat(os.Getenv(envAPISecSampleRate), 64)
+	value := os.Getenv(envAPISecSampleRate)
+	rate, err := strconv.ParseFloat(value, 64)
 	if err != nil {
-		log.Debugf("appsec: could not parse %s. Defaulting to %f", envAPISecSampleRate, defaultAPISecSampleRate)
+		logEnvVarParsingError(envAPISecSampleRate, value, err, defaultAPISecSampleRate)
 		return defaultAPISecSampleRate
 	}
 	if rate < 0. || rate > 1. {
-		log.Debugf("appsec: %s value must be between 0 and 1. Defaulting to %f", envAPISecSampleRate, defaultAPISecSampleRate)
+		logUnexpectedEnvVarValue(envAPISecSampleRate, rate, "value must be between 0 and 1", defaultAPISecSampleRate)
 		return defaultAPISecSampleRate
 	}
 	return rate
@@ -89,7 +90,7 @@ func readObfuscatorConfigRegexp(name, defaultValue string) string {
 		return defaultValue
 	}
 	if _, err := regexp.Compile(val); err != nil {
-		log.Errorf("appsec: could not compile the configured obfuscator regular expression `%s=%s`. Using the default value instead", name, val)
+		logUnexpectedEnvVarValue(name, val, "could not compile the configured obfuscator regular expression", defaultValue)
 		return defaultValue
 	}
 	log.Debug("appsec: starting with the configured obfuscator regular expression %s", name)

--- a/appsec/config_test.go
+++ b/appsec/config_test.go
@@ -57,7 +57,21 @@ func TestAPISecConfig(t *testing.T) {
 			enabledVar:    "true",
 			sampleRateVar: "1.0",
 			enabled:       true,
-			sampleRate:    1.0,
+			sampleRate:    1.,
+		},
+		{
+			name:          "sampleRate 50.0",
+			enabledVar:    "true",
+			sampleRateVar: "50.0",
+			enabled:       true,
+			sampleRate:    1.,
+		},
+		{
+			name:          "sampleRate -50.0",
+			enabledVar:    "true",
+			sampleRateVar: "-50.0",
+			enabled:       true,
+			sampleRate:    0.,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/appsec/config_test.go
+++ b/appsec/config_test.go
@@ -1,0 +1,124 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package appsec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPISecConfig(t *testing.T) {
+	t.Run("API Security", func(t *testing.T) {
+		for _, tc := range []struct {
+			name          string
+			enabledVar    string
+			sampleRateVar string
+			enabled       bool
+			sampleRate    float64
+		}{
+			{
+				name:       "disabled",
+				sampleRate: defaultAPISecSampleRate,
+			},
+			{
+				name:       "disabled",
+				enabledVar: "false",
+				sampleRate: defaultAPISecSampleRate,
+			},
+			{
+				name:       "disabled",
+				enabledVar: "0",
+				sampleRate: defaultAPISecSampleRate,
+			},
+			{
+				name:       "disabled",
+				enabledVar: "weirdvalue",
+				sampleRate: defaultAPISecSampleRate,
+			},
+			{
+				name:       "enabled",
+				enabledVar: "true",
+				enabled:    true,
+				sampleRate: defaultAPISecSampleRate,
+			},
+			{
+				name:       "enabled",
+				enabledVar: "1",
+				enabled:    true,
+				sampleRate: defaultAPISecSampleRate,
+			},
+			{
+				name:          "sampleRate 1.0",
+				enabledVar:    "true",
+				sampleRateVar: "1.0",
+				enabled:       true,
+				sampleRate:    1.0,
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Setenv(envAPISecEnabled, tc.enabledVar)
+				t.Setenv(envAPISecSampleRate, tc.sampleRateVar)
+				cfg := NewAPISecConfig()
+				require.Equal(t, tc.enabled, cfg.Enabled)
+				require.Equal(t, tc.sampleRate, cfg.SampleRate)
+			})
+		}
+
+	})
+}
+
+func TestObfuscatorConfig(t *testing.T) {
+	defaultConfig := ObfuscatorConfig{
+		KeyRegex:   defaultObfuscatorKeyRegex,
+		ValueRegex: defaultObfuscatorValueRegex,
+	}
+	t.Run("obfuscator", func(t *testing.T) {
+		t.Run("key-regexp", func(t *testing.T) {
+			t.Run("env-var-normal", func(t *testing.T) {
+				expCfg := defaultConfig
+				expCfg.KeyRegex = "test"
+				t.Setenv(envObfuscatorKey, "test")
+				cfg := NewObfuscatorConfig()
+				require.Equal(t, expCfg, cfg)
+			})
+			t.Run("env-var-empty", func(t *testing.T) {
+				expCfg := defaultConfig
+				expCfg.KeyRegex = ""
+				t.Setenv(envObfuscatorKey, "")
+				cfg := NewObfuscatorConfig()
+				require.Equal(t, expCfg, cfg)
+			})
+			t.Run("compile-error", func(t *testing.T) {
+				t.Setenv(envObfuscatorKey, "+")
+				cfg := NewObfuscatorConfig()
+				require.Equal(t, defaultConfig, cfg)
+			})
+		})
+
+		t.Run("value-regexp", func(t *testing.T) {
+			t.Run("env-var-normal", func(t *testing.T) {
+				expCfg := defaultConfig
+				expCfg.ValueRegex = "test"
+				t.Setenv(envObfuscatorValue, "test")
+				cfg := NewObfuscatorConfig()
+				require.Equal(t, expCfg, cfg)
+			})
+			t.Run("env-var-empty", func(t *testing.T) {
+				expCfg := defaultConfig
+				expCfg.ValueRegex = ""
+				t.Setenv(envObfuscatorValue, "")
+				cfg := NewObfuscatorConfig()
+				require.Equal(t, expCfg, cfg)
+			})
+			t.Run("compile-error", func(t *testing.T) {
+				t.Setenv(envObfuscatorValue, "+")
+				cfg := NewObfuscatorConfig()
+				require.Equal(t, defaultConfig, cfg)
+			})
+		})
+	})
+}

--- a/appsec/config_test.go
+++ b/appsec/config_test.go
@@ -14,63 +14,60 @@ import (
 )
 
 func TestAPISecConfig(t *testing.T) {
-	t.Run("API Security", func(t *testing.T) {
-		for _, tc := range []struct {
-			name          string
-			enabledVar    string
-			sampleRateVar string
-			enabled       bool
-			sampleRate    float64
-		}{
-			{
-				name:       "disabled",
-				sampleRate: defaultAPISecSampleRate,
-			},
-			{
-				name:       "disabled",
-				enabledVar: "false",
-				sampleRate: defaultAPISecSampleRate,
-			},
-			{
-				name:       "disabled",
-				enabledVar: "0",
-				sampleRate: defaultAPISecSampleRate,
-			},
-			{
-				name:       "disabled",
-				enabledVar: "weirdvalue",
-				sampleRate: defaultAPISecSampleRate,
-			},
-			{
-				name:       "enabled",
-				enabledVar: "true",
-				enabled:    true,
-				sampleRate: defaultAPISecSampleRate,
-			},
-			{
-				name:       "enabled",
-				enabledVar: "1",
-				enabled:    true,
-				sampleRate: defaultAPISecSampleRate,
-			},
-			{
-				name:          "sampleRate 1.0",
-				enabledVar:    "true",
-				sampleRateVar: "1.0",
-				enabled:       true,
-				sampleRate:    1.0,
-			},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				t.Setenv(envAPISecEnabled, tc.enabledVar)
-				t.Setenv(envAPISecSampleRate, tc.sampleRateVar)
-				cfg := NewAPISecConfig()
-				require.Equal(t, tc.enabled, cfg.Enabled)
-				require.Equal(t, tc.sampleRate, cfg.SampleRate)
-			})
-		}
-
-	})
+	for _, tc := range []struct {
+		name          string
+		enabledVar    string
+		sampleRateVar string
+		enabled       bool
+		sampleRate    float64
+	}{
+		{
+			name:       "disabled",
+			sampleRate: defaultAPISecSampleRate,
+		},
+		{
+			name:       "disabled",
+			enabledVar: "false",
+			sampleRate: defaultAPISecSampleRate,
+		},
+		{
+			name:       "disabled",
+			enabledVar: "0",
+			sampleRate: defaultAPISecSampleRate,
+		},
+		{
+			name:       "disabled",
+			enabledVar: "weirdvalue",
+			sampleRate: defaultAPISecSampleRate,
+		},
+		{
+			name:       "enabled",
+			enabledVar: "true",
+			enabled:    true,
+			sampleRate: defaultAPISecSampleRate,
+		},
+		{
+			name:       "enabled",
+			enabledVar: "1",
+			enabled:    true,
+			sampleRate: defaultAPISecSampleRate,
+		},
+		{
+			name:          "sampleRate 1.0",
+			enabledVar:    "true",
+			sampleRateVar: "1.0",
+			enabled:       true,
+			sampleRate:    1.0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envAPISecEnabled, tc.enabledVar)
+			t.Setenv(envAPISecSampleRate, tc.sampleRateVar)
+			cfg := NewAPISecConfig()
+			require.Equal(t, tc.enabled, cfg.Enabled)
+			require.Equal(t, tc.sampleRate, cfg.SampleRate)
+		})
+	}
 }
 
 func TestObfuscatorConfig(t *testing.T) {
@@ -78,50 +75,44 @@ func TestObfuscatorConfig(t *testing.T) {
 		KeyRegex:   defaultObfuscatorKeyRegex,
 		ValueRegex: defaultObfuscatorValueRegex,
 	}
-	t.Run("obfuscator", func(t *testing.T) {
-		t.Run("key-regexp", func(t *testing.T) {
-			t.Run("env-var-normal", func(t *testing.T) {
-				expCfg := defaultConfig
-				expCfg.KeyRegex = "test"
-				t.Setenv(envObfuscatorKey, "test")
-				cfg := NewObfuscatorConfig()
-				require.Equal(t, expCfg, cfg)
-			})
-			t.Run("env-var-empty", func(t *testing.T) {
-				expCfg := defaultConfig
-				expCfg.KeyRegex = ""
-				t.Setenv(envObfuscatorKey, "")
-				cfg := NewObfuscatorConfig()
-				require.Equal(t, expCfg, cfg)
-			})
-			t.Run("compile-error", func(t *testing.T) {
-				t.Setenv(envObfuscatorKey, "+")
-				cfg := NewObfuscatorConfig()
-				require.Equal(t, defaultConfig, cfg)
-			})
-		})
+	t.Run("key/env-var-normal", func(t *testing.T) {
+		expCfg := defaultConfig
+		expCfg.KeyRegex = "test"
+		t.Setenv(envObfuscatorKey, "test")
+		cfg := NewObfuscatorConfig()
+		require.Equal(t, expCfg, cfg)
+	})
+	t.Run("key/env-var-empty", func(t *testing.T) {
+		expCfg := defaultConfig
+		expCfg.KeyRegex = ""
+		t.Setenv(envObfuscatorKey, "")
+		cfg := NewObfuscatorConfig()
+		require.Equal(t, expCfg, cfg)
+	})
+	t.Run("key/compile-error", func(t *testing.T) {
+		t.Setenv(envObfuscatorKey, "+")
+		cfg := NewObfuscatorConfig()
+		require.Equal(t, defaultConfig, cfg)
+	})
 
-		t.Run("value-regexp", func(t *testing.T) {
-			t.Run("env-var-normal", func(t *testing.T) {
-				expCfg := defaultConfig
-				expCfg.ValueRegex = "test"
-				t.Setenv(envObfuscatorValue, "test")
-				cfg := NewObfuscatorConfig()
-				require.Equal(t, expCfg, cfg)
-			})
-			t.Run("env-var-empty", func(t *testing.T) {
-				expCfg := defaultConfig
-				expCfg.ValueRegex = ""
-				t.Setenv(envObfuscatorValue, "")
-				cfg := NewObfuscatorConfig()
-				require.Equal(t, expCfg, cfg)
-			})
-			t.Run("compile-error", func(t *testing.T) {
-				t.Setenv(envObfuscatorValue, "+")
-				cfg := NewObfuscatorConfig()
-				require.Equal(t, defaultConfig, cfg)
-			})
-		})
+	t.Run("value/env-var-normal", func(t *testing.T) {
+		expCfg := defaultConfig
+		expCfg.ValueRegex = "test"
+		t.Setenv(envObfuscatorValue, "test")
+		cfg := NewObfuscatorConfig()
+		require.Equal(t, expCfg, cfg)
+	})
+	t.Run("value/env-var-empty", func(t *testing.T) {
+		expCfg := defaultConfig
+		expCfg.ValueRegex = ""
+		t.Setenv(envObfuscatorValue, "")
+		cfg := NewObfuscatorConfig()
+		require.Equal(t, expCfg, cfg)
+	})
+	t.Run("value/compile-error", func(t *testing.T) {
+		t.Setenv(envObfuscatorValue, "+")
+		cfg := NewObfuscatorConfig()
+		require.Equal(t, defaultConfig, cfg)
 	})
 }
 
@@ -157,7 +148,7 @@ func TestTraceRateLimit(t *testing.T) {
 			expected: defaultTraceRate,
 		},
 	} {
-		t.Run("trace-rate-limit/"+tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv(envTraceRateLimit, tc.env)
 			require.Equal(t, tc.expected, RateLimitFromEnv())
 		})
@@ -201,7 +192,7 @@ func TestWAFTimeout(t *testing.T) {
 			expected: defaultWAFTimeout,
 		},
 	} {
-		t.Run("waf-timeout/"+tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv(envWafTimeout, tc.env)
 			require.Equal(t, tc.expected, WAFTimeoutFromEnv())
 		})
@@ -210,34 +201,32 @@ func TestWAFTimeout(t *testing.T) {
 }
 
 func TestRules(t *testing.T) {
-	t.Run("rules", func(t *testing.T) {
-		t.Run("empty-string", func(t *testing.T) {
-			t.Setenv(envRules, "")
-			rules, err := RulesFromEnv()
-			require.NoError(t, err)
-			require.Equal(t, StaticRecommendedRules, string(rules))
-		})
+	t.Run("empty-string", func(t *testing.T) {
+		t.Setenv(envRules, "")
+		rules, err := RulesFromEnv()
+		require.NoError(t, err)
+		require.Equal(t, StaticRecommendedRules, string(rules))
+	})
 
-		t.Run("file-not-found", func(t *testing.T) {
-			t.Setenv(envRules, "i do not exist")
-			rules, err := RulesFromEnv()
-			require.Error(t, err)
-			require.Nil(t, rules)
-		})
+	t.Run("file-not-found", func(t *testing.T) {
+		t.Setenv(envRules, "i do not exist")
+		rules, err := RulesFromEnv()
+		require.Error(t, err)
+		require.Nil(t, rules)
+	})
 
-		t.Run("local-file", func(t *testing.T) {
-			file, err := os.CreateTemp("", "example-*")
-			require.NoError(t, err)
-			defer func() {
-				file.Close()
-				os.Remove(file.Name())
-			}()
-			_, err = file.WriteString(StaticRecommendedRules)
-			require.NoError(t, err)
-			t.Setenv(envRules, file.Name())
-			rules, err := RulesFromEnv()
-			require.NoError(t, err)
-			require.Equal(t, StaticRecommendedRules, string(rules))
-		})
+	t.Run("local-file", func(t *testing.T) {
+		file, err := os.CreateTemp("", "example-*")
+		require.NoError(t, err)
+		defer func() {
+			file.Close()
+			os.Remove(file.Name())
+		}()
+		_, err = file.WriteString(StaticRecommendedRules)
+		require.NoError(t, err)
+		t.Setenv(envRules, file.Name())
+		rules, err := RulesFromEnv()
+		require.NoError(t, err)
+		require.Equal(t, StaticRecommendedRules, string(rules))
 	})
 }

--- a/appsec/config_test.go
+++ b/appsec/config_test.go
@@ -122,3 +122,32 @@ func TestObfuscatorConfig(t *testing.T) {
 		})
 	})
 }
+
+func TestTraceRateLimit(t *testing.T) {
+	t.Run("trace-rate-limit", func(t *testing.T) {
+		t.Run("parsable", func(t *testing.T) {
+			t.Setenv(envTraceRateLimit, "1234567890")
+			require.Equal(t, uint(1234567890), RateLimitFromEnv())
+		})
+
+		t.Run("not-parsable", func(t *testing.T) {
+			t.Setenv(envTraceRateLimit, "not a uint")
+			require.Equal(t, defaultTraceRate, RateLimitFromEnv())
+		})
+
+		t.Run("negative", func(t *testing.T) {
+			t.Setenv(envTraceRateLimit, "-1")
+			require.Equal(t, defaultTraceRate, RateLimitFromEnv())
+		})
+
+		t.Run("zero", func(t *testing.T) {
+			t.Setenv(envTraceRateLimit, "0")
+			require.Equal(t, defaultTraceRate, RateLimitFromEnv())
+		})
+
+		t.Run("empty-string", func(t *testing.T) {
+			t.Setenv(envTraceRateLimit, "")
+			require.Equal(t, defaultTraceRate, RateLimitFromEnv())
+		})
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,18 @@ module github.com/DataDog/appsec-internal-go
 go 1.18
 
 require (
+	github.com/DataDog/datadog-agent/pkg/util/log v0.49.0
 	github.com/stretchr/testify v1.8.2
 	inet.af/netaddr v0.0.0-20220811202034-502d2d690317
 )
 
 require (
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.49.0 // indirect
+	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,9 @@
+github.com/DataDog/datadog-agent/pkg/util/log v0.49.0 h1:cyOCabSFaOKGGkpYv985xkAdUjvhtL2zfjd0pigUJX4=
+github.com/DataDog/datadog-agent/pkg/util/log v0.49.0/go.mod h1:h0DfsKCkiQYZzVKCpODobZia0OkHAGN98sTSlqoA7so=
+github.com/DataDog/datadog-agent/pkg/util/scrubber v0.49.0 h1:bYkTMqlKZMHaoDJ8oy8WWh3hklh5xzaV9tyQgofktb0=
+github.com/DataDog/datadog-agent/pkg/util/scrubber v0.49.0/go.mod h1:EOGgNrSPskIxY3+KgCl+yEggMjrGqrA2oL5va+/p2jM=
+github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 h1:kHaBemcxl8o/pQ5VM1c8PVE1PubbNx3mjUr09OqWGCs=
+github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -40,6 +46,8 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Shared configs
Add shared configuration. This is currently duplicated between tracer and agent.
This includes:

- obfuscator config
- waf timeout config
- trace rate limit config
- api sec config
- rules config

## MIssing

The appsec enabled logic is not there as it is not configured through the same env vars in tracer and serverless,
so it makes sense that each pkg would have its own code.