### PR TITLE
appsec/config: use DefaultRules() in RulesFromEnv()

### DIFF
--- a/appsec/config.go
+++ b/appsec/config.go
@@ -154,7 +154,7 @@ func RulesFromEnv() ([]byte, error) {
 	filepath := os.Getenv(envRules)
 	if filepath == "" {
 		log.Debug("appsec: using the default built-in recommended security rules")
-		return []byte(StaticRecommendedRules), nil
+		return DefaultRuleset()
 	}
 	buf, err := os.ReadFile(filepath)
 	if err != nil {

--- a/appsec/config_test.go
+++ b/appsec/config_test.go
@@ -216,10 +216,12 @@ func TestWAFTimeout(t *testing.T) {
 
 func TestRules(t *testing.T) {
 	t.Run("empty-string", func(t *testing.T) {
+		defaultRules, err := DefaultRuleset()
+		require.NoError(t, err)
 		t.Setenv(envRules, "")
 		rules, err := RulesFromEnv()
 		require.NoError(t, err)
-		require.Equal(t, StaticRecommendedRules, string(rules))
+		require.Equal(t, defaultRules, rules)
 	})
 
 	t.Run("file-not-found", func(t *testing.T) {

--- a/appsec/rules.go
+++ b/appsec/rules.go
@@ -6,8 +6,17 @@ package appsec
 
 import "encoding/json"
 
-// DefaultRuleset returns the default recommended security rules for AppSec
+// DefaultRuleset returns the marshaled default recommended security rules for AppSec
 func DefaultRuleset() ([]byte, error) {
+	rules, err := DefaultRulesetMap()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(rules)
+}
+
+// DefaultRulesetMap returns the unmarshaled default recommended security rules for AppSec
+func DefaultRulesetMap() (map[string]any, error) {
 	var rules map[string]any
 	var processors map[string]any
 	if err := json.Unmarshal([]byte(StaticRecommendedRules), &rules); err != nil {
@@ -20,5 +29,5 @@ func DefaultRuleset() ([]byte, error) {
 		rules[k] = v
 	}
 
-	return json.Marshal(rules)
+	return rules, nil
 }


### PR DESCRIPTION
Use `DefaultRules()` in `RulesFromEnv()` to default to static recommended rules *and* processors/scanners in case we can't read the env.
This makes sure that processors config aggregation logic doesn't have to be handled anywhere other than here, while we wait for sec rules to include those by default.