### PR TITLE
chore: make update workflow authenticate

### DIFF
--- a/.github/workflows/update-rules.yml
+++ b/.github/workflows/update-rules.yml
@@ -14,7 +14,9 @@ jobs:
       - uses: actions/setup-go@v3
       - name: Upgrade AppSec Rules
         run: ./_tools/rules-updater/update.sh latest
-      - name: Detect Udpated Code
+        env:
+          GITHUB_TOKEN: ${{ secrets.UPDATE_RULES_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Detect Updated Code
         id: detect
         run: |-
           git add .
@@ -60,4 +62,4 @@ jobs:
             --base "main" --head "automation/update-appsec-rules" \
             --reviewer "@DataDog/asm-go"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.UPDATE_RULES_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-rules.yml
+++ b/.github/workflows/update-rules.yml
@@ -62,4 +62,4 @@ jobs:
             --base "main" --head "automation/update-appsec-rules" \
             --reviewer "@DataDog/asm-go"
         env:
-          GITHUB_TOKEN: ${{ secrets.UPDATE_RULES_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.MUTATOR_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/_tools/rules-updater/Dockerfile
+++ b/_tools/rules-updater/Dockerfile
@@ -5,14 +5,23 @@ COPY writer/ /home/
 WORKDIR /home/
 
 ARG version
+ARG GITHUB_TOKEN
 
 RUN if [ "${version}" = "latest" ]; then \
-  curl -s 'https://api.github.com/repos/DataDog/appsec-event-rules/releases/latest' | jq -r '.tag_name' > .version; \
+  curl \
+    --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+    --header "X-Github-Api-Version: 2022-11-28" \
+    -fSsL 'https://api.github.com/repos/DataDog/appsec-event-rules/releases/latest' \
+  | jq -r '.tag_name' > .version; \
   else \
   echo "${version}" > .version; \
   fi
 
-RUN curl -fSsL "https://raw.githubusercontent.com/DataDog/appsec-event-rules/$(cat .version)/build/recommended.json" -o /home/rules.json
+RUN curl \
+    --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+    --header "X-Github-Api-Version: 2022-11-28" \
+    -fSsL "https://raw.githubusercontent.com/DataDog/appsec-event-rules/$(cat .version)/build/recommended.json" \
+    -o /home/rules.json
 RUN go run writer.go $(cat .version) > embed.go
 
 FROM scratch

--- a/_tools/rules-updater/update.sh
+++ b/_tools/rules-updater/update.sh
@@ -17,6 +17,12 @@ set -eu
 
 [ $# -ne 1 ] && echo "Usage: $0 \"version\"" >&2 && exit 1
 
+if [ -z ${GITHUB_TOKEN:-} ]; then
+  echo "The GITHUB_TOKEN environmnent variable must be set to a valid GitHub"
+  echo "token with read access to the DataDog/appsec-event-rules repository."
+  exit 1
+fi
+
 echo "================ Minifying ================"
 
 tmpDir="$(mktemp -d /tmp/rule-update-XXXXXXXXX)"
@@ -26,7 +32,7 @@ destDir="$(readlink -f "$scriptDir/../../appsec/")"
 
 trap "rm -r $tmpDir" EXIT
 
-DOCKER_BUILDKIT=1 docker build -o type=local,dest="$tmpDir" --build-arg version="$1" --no-cache "$scriptDir"
+DOCKER_BUILDKIT=1 docker build -o type=local,dest="$tmpDir" --build-arg version="$1" --build-arg GITHUB_TOKEN="${GITHUB_TOKEN}" --no-cache "$scriptDir"
 echo "================   Done    ================"
 cp -v $tmpDir/embed.go $tmpDir/rules.json "$destDir"
 echo "Output written to $destDir"


### PR DESCRIPTION
Since the DataDog/appsec-event-rules repository has been made internal, it is now necessary to authenticate in order to be able to access releases, etc...