### PR TITLE
appsec/config: 1 ms default WAF timeout

### DIFF
--- a/appsec/config.go
+++ b/appsec/config.go
@@ -42,8 +42,8 @@ const (
 	DefaultObfuscatorKeyRegex = `(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?)key)|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization`
 	// DefaultObfuscatorValueRegex is the default regexp used to obfuscate values
 	DefaultObfuscatorValueRegex = `(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:\s*=[^;]|"\s*:\s*"[^"]+")|bearer\s+[a-z0-9\._\-]+|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\w=-]+\.ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}[^\-]+[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,}`
-	// DefaultWAFTimeout is the default time limit (ms) past which a WAF run will timeout
-	DefaultWAFTimeout = 4 * time.Millisecond
+	// DefaultWAFTimeout is the default time limit past which a WAF run will timeout
+	DefaultWAFTimeout = time.Millisecond
 	// DefaultTraceRate is the default limit (trace/sec) past which ASM traces are sampled out
 	DefaultTraceRate uint = 100 // up to 100 appsec traces/s
 )


### PR DESCRIPTION
Now that go-libddwaf has been so much optimized with 0-copies, we can lower our default timeout to 1 ms and be at this limit we know our sec rules might need to run.

The goal is to have less impact on O(10ms) servers. 4ms was fine for >= O(100ms).