### PR TITLE
fix: correct wrong APISec config test behaviour

### DIFF
--- a/appsec/config_test.go
+++ b/appsec/config_test.go
@@ -32,11 +32,6 @@ func TestAPISecConfig(t *testing.T) {
 			sampleRate: DefaultAPISecSampleRate,
 		},
 		{
-			name:       "disabled",
-			enabledVar: "weirdvalue",
-			sampleRate: DefaultAPISecSampleRate,
-		},
-		{
 			name:       "enabled",
 			enabled:    true,
 			sampleRate: DefaultAPISecSampleRate,
@@ -50,6 +45,12 @@ func TestAPISecConfig(t *testing.T) {
 		{
 			name:       "enabled",
 			enabledVar: "1",
+			enabled:    true,
+			sampleRate: DefaultAPISecSampleRate,
+		},
+		{
+			name:       "enabled",
+			enabledVar: "weirdvalue",
 			enabled:    true,
 			sampleRate: DefaultAPISecSampleRate,
 		},


### PR DESCRIPTION
The behaviour for API Sec configuration evaluation in case the env var is set but has an incorrect value was wrong.
The behaviour should be to revert back to the default value, which is true. The config code behaved correctly, but we tested the opposite.