### PR TITLE
ci: rollout macos-11 in favor of macos-14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     name: Native ${{ matrix.runs-on }} (Go ${{ matrix.go-version }}, CGO_ENABLED=${{ matrix.cgo_enabled }})
     strategy:
       matrix:
-        runs-on: [ macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest ]
+        runs-on: [ macos-14, macos-13, macos-12, ubuntu-22.04, ubuntu-20.04, windows-latest ]
         go-version: [ "1.21", "1.20", "1.19" ]
         cgo_enabled: [ "0", "1" ] # test it compiles with and without cgo
       fail-fast: false


### PR DESCRIPTION
GitHub is deprecating macos-11 runners so we need to swap them out