### PR TITLE
feat: ruleset v1.13.1

### DIFF
--- a/_tools/rules-updater/Dockerfile
+++ b/_tools/rules-updater/Dockerfile
@@ -1,13 +1,14 @@
-FROM golang:1.21 as go-format
+# syntax=docker/dockerfile:1
+FROM golang:1.21 AS go-format
 
 RUN apt update && apt install -y jq curl
 COPY writer/ /home/
 WORKDIR /home/
 
 ARG version
-ARG GITHUB_TOKEN
 
-RUN if [ "${version}" = "latest" ]; then \
+RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
+  if [ "${version}" = "latest" ]; then \
   curl \
     --header "Authorization: Bearer ${GITHUB_TOKEN}" \
     --header "X-Github-Api-Version: 2022-11-28" \
@@ -17,7 +18,8 @@ RUN if [ "${version}" = "latest" ]; then \
   echo "${version}" > .version; \
   fi
 
-RUN curl \
+RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
+  curl \
     --header "Authorization: Bearer ${GITHUB_TOKEN}" \
     --header "X-Github-Api-Version: 2022-11-28" \
     -fSsL "https://raw.githubusercontent.com/DataDog/appsec-event-rules/$(cat .version)/build/recommended.json" \

--- a/_tools/rules-updater/update.sh
+++ b/_tools/rules-updater/update.sh
@@ -32,7 +32,7 @@ destDir="$(readlink -f "$scriptDir/../../appsec/")"
 
 trap "rm -r $tmpDir" EXIT
 
-DOCKER_BUILDKIT=1 docker build -o type=local,dest="$tmpDir" --build-arg version="$1" --build-arg GITHUB_TOKEN="${GITHUB_TOKEN}" --no-cache "$scriptDir"
+DOCKER_BUILDKIT=1 docker build -o type=local,dest="$tmpDir" --build-arg version="$1" --secret "id=GITHUB_TOKEN,env=GITHUB_TOKEN" --no-cache "$scriptDir"
 echo "================   Done    ================"
 cp -v $tmpDir/embed.go $tmpDir/rules.json "$destDir"
 echo "Output written to $destDir"

--- a/appsec/embed.go
+++ b/appsec/embed.go
@@ -7,8 +7,8 @@ package appsec
 
 import _ "embed" // Blank import comment for golint compliance
 
-// StaticRecommendedRules holds the recommended AppSec security rules (v1.13.0)
-// Source: https://github.com/DataDog/appsec-event-rules/blob/1.13.0/build/recommended.json
+// StaticRecommendedRules holds the recommended AppSec security rules (v1.13.1)
+// Source: https://github.com/DataDog/appsec-event-rules/blob/1.13.1/build/recommended.json
 //
 //go:embed rules.json
 var StaticRecommendedRules string

--- a/appsec/rules.json
+++ b/appsec/rules.json
@@ -6286,7 +6286,7 @@
     },
     {
       "id": "rasp-932-100",
-      "name": "Shell injection exploit",
+      "name": "Command injection exploit",
       "tags": {
         "type": "command_injection",
         "category": "vulnerability_trigger",
@@ -6335,6 +6335,7 @@
     {
       "id": "rasp-934-100",
       "name": "Server-side request forgery exploit",
+      "enabled": false,
       "tags": {
         "type": "ssrf",
         "category": "vulnerability_trigger",
@@ -6383,6 +6384,7 @@
     {
       "id": "rasp-942-100",
       "name": "SQL injection exploit",
+      "enabled": false,
       "tags": {
         "type": "sql_injection",
         "category": "vulnerability_trigger",


### PR DESCRIPTION
Additionally, update `Dockerfile` to use the relatively new secrets feature to pass the `GITHUB_TOKEN`, in order to adhere to best practices.