### PR TITLE
Update third party actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,7 @@
 name: Test
 on:
   workflow_dispatch: # manually
-  schedule: # nightly
-    - cron: "0 0 * * *"
-  pull_request:
-    types: [opened, reopened, synchronize]
+  pull_request: # default behaviour opened, reopened, synchronize, edited, ready_for_review
   merge_group:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,8 @@ on:
   workflow_dispatch: # manually
   schedule: # nightly
     - cron: "0 0 * * *"
-  pull_request: {}
+  pull_request:
+    types: [opened, reopened, synchronize]
   merge_group:
     branches:
       - main
@@ -23,14 +24,14 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
 
       - name: Go modules cache
-        uses: actions/cache@v3
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/go/pkg/mod
           key: go-pkg-mod-${{ hashFiles('**/go.sum') }}
@@ -57,13 +58,13 @@ jobs:
         cgo_enabled: [ "0", "1" ] # test it compiles with and without cgo
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       # Install gcc and the libc headers on alpine images
       - if: ${{ matrix.distribution == 'alpine' }}
         run: apk add gcc musl-dev libc6-compat git
 
       - name: Go modules cache
-        uses: actions/cache@v3
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/go/pkg/mod
           key: go-pkg-mod-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/update-rules.yml
+++ b/.github/workflows/update-rules.yml
@@ -10,8 +10,8 @@ jobs:
     outputs:
       mutation_happened: ${{ steps.detect.outputs.mutation_happened }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       - name: Upgrade AppSec Rules
         run: ./_tools/rules-updater/update.sh latest
         env:
@@ -23,7 +23,7 @@ jobs:
           git diff --staged --patch --exit-code > ${{ runner.temp }}/repo.patch || echo "mutation_happened=true" >> $GITHUB_OUTPUT
       - name: Upload Patch
         if: steps.detect.outputs.mutation_happened
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: repo.patch
           path: ${{ runner.temp }}/repo.patch
@@ -35,9 +35,9 @@ jobs:
       contents: write
     if: needs.update.outputs.mutation_happened
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Download Patch
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: repo.patch
           path: ${{ runner.temp }}


### PR DESCRIPTION
`upload-artifact` and `download-artifact` were outdated and causing [job failures](https://github.com/DataDog/appsec-internal-go/actions/runs/13115825664)

-  `checkout` `upload-artifact` and `download-artifact` to v4 
- `setup-go` to v5
- all pinned to specific releases