### PR TITLE
fix: allow system tests to override API Security sampling interval

### DIFF
--- a/apisec/internal/config/const.go
+++ b/apisec/internal/config/const.go
@@ -5,12 +5,7 @@
 
 package config
 
-import "time"
-
 const (
 	// MaxItemCount is the maximum amount of items to keep in a timed set.
 	MaxItemCount = 4_096
-
-	// Interval is the interval between two samples being taken.
-	Interval = 30 * time.Second
 )

--- a/apisec/internal/timed/lru.go
+++ b/apisec/internal/timed/lru.go
@@ -7,11 +7,13 @@ package timed
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/appsec-internal-go/apisec/internal/config"
+	"github.com/DataDog/appsec-internal-go/log"
 )
 
 // capacity is the maximum number of items that may be temporarily present in a
@@ -45,17 +47,18 @@ type LRU struct {
 }
 
 // NewSet initializes a new, empty [LRU] with the given interval and clock
-// function. The provided interval must be at least 1 second, and may not exceed
-// [config.Interval].
+// function. A warning will be logged if it is set below 1 second. Panics if
+// the interval is more than [math.MaxUint32] seconds, as this value cannot be
+// used internally.
 //
 // Note: timestamps are stored at second resolution, so the interval will be
 // rounded down to the nearest second.
 func NewSet(interval time.Duration, clock ClockFunc) *LRU {
 	if interval < time.Second {
-		panic(fmt.Errorf("NewSet: interval must be at least 1s, got %v", interval))
+		log.Warn("NewSet: interval is less than one second; this should not be attempted in production (value: %s)", interval)
 	}
-	if interval > config.Interval {
-		panic(fmt.Errorf("NewSet: interval must not exceed %s, got %v", config.Interval, interval))
+	if interval > time.Second*math.MaxUint32 {
+		panic(fmt.Errorf("NewSet: interval must be <= %s, but was %s", time.Second*math.MaxUint32, interval))
 	}
 
 	intervalSeconds := uint32(interval.Seconds())

--- a/apisec/internal/timed/lru.go
+++ b/apisec/internal/timed/lru.go
@@ -46,19 +46,19 @@ type LRU struct {
 	rebuilding atomic.Bool
 }
 
-// NewSet initializes a new, empty [LRU] with the given interval and clock
+// NewLRU initializes a new, empty [LRU] with the given interval and clock
 // function. A warning will be logged if it is set below 1 second. Panics if
 // the interval is more than [math.MaxUint32] seconds, as this value cannot be
 // used internally.
 //
 // Note: timestamps are stored at second resolution, so the interval will be
 // rounded down to the nearest second.
-func NewSet(interval time.Duration, clock ClockFunc) *LRU {
+func NewLRU(interval time.Duration, clock ClockFunc) *LRU {
 	if interval < time.Second {
-		log.Warn("NewSet: interval is less than one second; this should not be attempted in production (value: %s)", interval)
+		log.Warn("NewLRU: interval is less than one second; this should not be attempted in production (value: %s)", interval)
 	}
 	if interval > time.Second*math.MaxUint32 {
-		panic(fmt.Errorf("NewSet: interval must be <= %s, but was %s", time.Second*math.MaxUint32, interval))
+		panic(fmt.Errorf("NewLRU: interval must be <= %s, but was %s", time.Second*math.MaxUint32, interval))
 	}
 
 	intervalSeconds := uint32(interval.Seconds())

--- a/apisec/internal/timed/lru_test.go
+++ b/apisec/internal/timed/lru_test.go
@@ -19,8 +19,8 @@ import (
 )
 
 func TestLRU(t *testing.T) {
-	t.Run("NewSet", func(t *testing.T) {
-		require.PanicsWithError(t, "NewSet: interval must be <= 1193046h28m15s, but was 1193046h28m16s", func() { NewSet(time.Second*(math.MaxUint32+1), UnixTime) })
+	t.Run("NewLRU", func(t *testing.T) {
+		require.PanicsWithError(t, "NewLRU: interval must be <= 1193046h28m15s, but was 1193046h28m16s", func() { NewLRU(time.Second*(math.MaxUint32+1), UnixTime) })
 	})
 
 	t.Run("Hit", func(t *testing.T) {
@@ -28,7 +28,7 @@ func TestLRU(t *testing.T) {
 		fakeClock := func() int64 { return fakeTime }
 
 		const sampleIntervalSeconds = 30
-		subject := NewSet(sampleIntervalSeconds*time.Second, fakeClock)
+		subject := NewLRU(sampleIntervalSeconds*time.Second, fakeClock)
 
 		require.True(t, subject.Hit(1337))
 		for range sampleIntervalSeconds {
@@ -63,7 +63,7 @@ func TestLRU(t *testing.T) {
 			clock.WaitUntilDone()
 		}()
 
-		subject := NewSet(30*time.Second, clock.Unix)
+		subject := NewLRU(30*time.Second, clock.Unix)
 
 		var (
 			startBarrier  sync.WaitGroup

--- a/apisec/sampler.go
+++ b/apisec/sampler.go
@@ -40,7 +40,7 @@ func NewSamplerWithInterval(interval time.Duration) Sampler {
 // newSampler allows creating a new [*Sampler] with custom clock function,
 // which is useful for testing.
 func newSampler(interval time.Duration, clock clockFunc) Sampler {
-	return (*timedSetSampler)(timed.NewSet(interval, clock))
+	return (*timedSetSampler)(timed.NewLRU(interval, clock))
 }
 
 // DecisionFor makes a sampling decision for the provided [SamplingKey]. If it

--- a/apisec/sampler.go
+++ b/apisec/sampler.go
@@ -10,7 +10,6 @@ import (
 	"hash/fnv"
 	"time"
 
-	"github.com/DataDog/appsec-internal-go/apisec/internal/config"
 	"github.com/DataDog/appsec-internal-go/apisec/internal/timed"
 )
 
@@ -33,14 +32,7 @@ type (
 	clockFunc = func() int64
 )
 
-// NewSampler returns a new [*Sampler] with the default clock function based on
-// [time.Now].
-func NewSampler() Sampler {
-	return NewSamplerWithInterval(config.Interval)
-}
-
-// NewSamplerWithInterval returns a new [*Sampler] with the specified interval
-// instead of the default of 30 seconds.
+// NewSamplerWithInterval returns a new [*Sampler] with the specified interval.
 func NewSamplerWithInterval(interval time.Duration) Sampler {
 	return newSampler(interval, timed.UnixTime)
 }

--- a/appsec/config_test.go
+++ b/appsec/config_test.go
@@ -238,3 +238,37 @@ func TestRASPEnablement(t *testing.T) {
 		require.True(t, RASPEnabled())
 	})
 }
+
+func TestDurationEnv(t *testing.T) {
+	const varName = "DD_TEST_VARIABLE_DURATION"
+
+	type testCase struct {
+		EnvVal   string
+		EnvUnit  string
+		Expected time.Duration
+	}
+	testCases := map[string]testCase{
+		"blank": {
+			EnvVal:   "",
+			EnvUnit:  "s",
+			Expected: 1337,
+		},
+		"1m": {
+			EnvVal:   "1",
+			EnvUnit:  "m",
+			Expected: time.Minute,
+		},
+		"invalid": {
+			EnvVal:   "invalid",
+			EnvUnit:  "s",
+			Expected: 1337,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(varName, tc.EnvVal)
+			require.Equal(t, tc.Expected, durationEnv(varName, tc.EnvUnit, 1337))
+		})
+	}
+}


### PR DESCRIPTION
Some system tests must override the sampling interval to 0 in order to
be able to test schema extraction works as intended. This requires
reading the default interval from an environment variable.